### PR TITLE
Fixed bug in GMRES

### DIFF
--- a/xitorch/_impls/linalg/solve.py
+++ b/xitorch/_impls/linalg/solve.py
@@ -388,7 +388,7 @@ def gmres(A: LinearOperator, B: torch.Tensor,
 
     for k in range(min(nr, max_niter)):
         y = A_fcn(q[k])  # torch.Size([*batch_dims, nr, ncols])
-        for j in range(k):
+        for j in range(k + 1):
             h[..., j, k] = _dot(q[j], y).reshape(-1, ncols)
             y = y - h[..., j, k].reshape(*batchdims, 1, ncols) * q[j]
 

--- a/xitorch/_tests/test_linop_fcns.py
+++ b/xitorch/_tests/test_linop_fcns.py
@@ -520,11 +520,8 @@ def test_solve_A_methods(dtype, device, method):
     assert list(x.shape) == xshape
 
     ax = LinearOperator.m(amat).mm(x)
-    if method == 'gmres':
-        # temporary solution until better convergence of gmres is obtained
-        assert torch.allclose(ax, bmat, atol=1e-1)
-    else:
-        assert torch.allclose(ax, bmat)
+
+    assert torch.allclose(ax, bmat)
 
 @device_dtype_float_test(only64=True, include_complex=True, additional_kwargs={
     "ashape": [(2, 2), (2, 2, 2), (2, 1, 2, 2)],


### PR DESCRIPTION
This PR fixes a bug in 7919bb0 that resulted in a large residual error even when the algorithm converged. The performance is now comparable to both cg and bicgstab.

Tested on A of size (100, 100) and b of size (2, 100, 100), the max norm of residual error in each case is:

- ``gmres`` 6.88e-06
- ``bicgstab`` 1.19e-05
- ``cg`` 1.01e-05

