### PR TITLE
Further issues with the publish script were resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
         poetry-version: [1.2.2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: '0'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -49,7 +51,9 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: '0'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,9 @@ jobs:
         poetry-version: [1.2.2]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: '0'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,9 +24,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Checkout repo and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@main
       with:
         submodules: recursive
+        fetch-depth: '0'
     - name: Build SLDENSE and test requirements
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: '0'
       - name: Build and publish to Test PyPI
         if: ${{ !(startsWith(github.ref, 'refs/tags')) || (inputs.test == true) }}
         uses: JRubics/poetry-publish@v1.16

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build-n-publish:
+    if: (github.ref_type == "tag" && endsWith(github.workflow_ref, "master")) || github.ref_type != "tag"
 
     name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build-n-publish:
-    if: (github.ref_type == "tag" && endsWith(github.workflow_ref, "master")) || github.ref_type != "tag"
+    if: (github.ref_type == 'tag' && endsWith(github.workflow_ref, 'master')) || (github.ref_type != 'tag')
 
     name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
         poetry-version: [1.2.2]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
         with:
           fetch-depth: '0'
       - name: Build and publish to Test PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,6 @@ format-jinja = """
 {%- if distance == 0 -%}
         {{ serialize_pep440(base) }}
 {%- else -%}
-        {%- if branch == 'master' -%}
-                {{serialize_pep440(bump_version(base, index=1), dev=timestamp)}}
-        {%- else -%}
-                {{serialize_pep440(bump_version(base, index=1))}}.dev+{{commit}}
-        {%- endif -%}
+        {{serialize_pep440(bump_version(base, index=1), dev=timestamp)}}
 {%- endif -%}
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ flake8 = "^6.0.0"
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
+strict = true
 format-jinja = """
 {%- if distance == 0 -%}
         {{ serialize_pep440(base) }}


### PR DESCRIPTION
List of addressed issues:

- Checkout action was out of date, as it referenced branch `master` rather than `main`.
- Checkout action didn't include tags, thereby breaking the automatic versioning.
- Tags would lead to push on PyPI from other branches than master (workflow `on: push` options are combined with `or` rather than `and`).
- Versioning wasn't `strict`, so if no tags were found, the placeholder "0.0.0" was used.

Current version:
- Only push from `master` branch
- Push tagged releases to PyPI and untagged dev versions to TestPyPI
- Add manual submission with the option to push to PyPI or TestPyPI for official maintainers.
- Make versioning `strict` and use deep-copy checkout action, s.t. version tags are always found and there is a failsafe if they aren't

Overall, this improves the publishing robustness while allowing flexible manual publishes.