### PR TITLE
Reduce overhead in rootsolver

### DIFF
--- a/xitorch/_impls/optimize/root/rootsolver.py
+++ b/xitorch/_impls/optimize/root/rootsolver.py
@@ -70,20 +70,19 @@ def _nonlin_solver(fcn, x0, params, method,
     # making the variable twice as long
     x_is_complex = torch.is_complex(x0)
 
-    def _ravel(x: torch.Tensor) -> torch.Tensor:
-        # represents x as a long real vector
-        if x_is_complex:
-            return torch.cat((x.real, x.imag), dim=0).reshape(-1)
-        else:
-            return x.reshape(-1)
+    def _ravel_complex(x: torch.Tensor) -> torch.Tensor:
+        # represents complex x as a long real vector
+        return torch.cat((x.real, x.imag), dim=0).reshape(-1)
 
-    def _pack(x: torch.Tensor) -> torch.Tensor:
-        # pack a long real vector into the shape accepted by fcn
-        if x_is_complex:
-            n = len(x) // 2
-            xreal, ximag = x[:n], x[n:]
-            x = xreal + 1j * ximag
+    def _pack_complex(x: torch.Tensor) -> torch.Tensor:
+        # pack a long real vector into a complex vector with the shape accepted by fcn
+        n = len(x) // 2
+        xreal, ximag = x[:n], x[n:]
+        x = xreal + 1j * ximag
         return x.reshape(xshape)
+
+    _ravel = _ravel_complex if x_is_complex else (lambda x: x.reshape(-1))
+    _pack = _pack_complex if x_is_complex else (lambda x: x.reshape(xshape))
 
     # shorthand for the function
     xshape = x0.shape
@@ -248,10 +247,12 @@ def linearmixing(fcn, x0, params=(),
 broyden1.__doc__ += _nonlin_solver.__doc__  # type: ignore
 broyden2.__doc__ += _nonlin_solver.__doc__  # type: ignore
 
-def _safe_norm(v):
-    if not torch.isfinite(v).all():
-        return torch.tensor(float("inf"), dtype=v.dtype, device=v.device)
-    return torch.norm(v)
+def _norm_sq(v):
+    # if not torch.isfinite(v).all():
+    #     return torch.tensor(float("inf"), dtype=v.dtype, device=v.device)
+    v1 = v.reshape(-1)
+    y = torch.dot(v1, v1)
+    return y
 
 def _nonline_line_search(func, x, y, dx, search_type="armijo", rdiff=1e-8, smin=1e-2):
     tmp_s = [0]
@@ -264,7 +265,7 @@ def _nonline_line_search(func, x, y, dx, search_type="armijo", rdiff=1e-8, smin=
             return tmp_phi[0]
         xt = x + s * dx
         v = func(xt)
-        p = _safe_norm(v)**2
+        p = _norm_sq(v)
         if store:
             tmp_s[0] = s
             tmp_phi[0] = p
@@ -360,8 +361,5 @@ class TerminationCondition(object):
         xnorm = x.norm()
         ynorm = y.norm()
         dxnorm = dx.norm()
-        xtcheck = dxnorm < self.x_tol
-        xrcheck = dxnorm < self.x_rtol * xnorm
-        ytcheck = ynorm < self.f_tol
-        yrcheck = ynorm < self.f_rtol * self.f0_norm
-        return xtcheck and xrcheck and ytcheck and yrcheck
+        return (dxnorm < self.x_tol) and (dxnorm < self.x_rtol * xnorm) and \
+            (ynorm < self.f_tol) and (ynorm < self.f_rtol * self.f0_norm)


### PR DESCRIPTION
Increases the speed by 10% on CPU. This is the benchmark I'm using:
```python
from typing import Tuple, Any
import torch
import numpy as np
from scipy.optimize import root
import xitorch
import xitorch.optimize


def benchmark_run(func, num_warmups: int = 5, num_runs: int = 10) -> Tuple[Any, float]:
    # doing a benchmark run and return the solution and the average time

    # warmup
    for _ in (range(num_warmups)):
        func()
    # run
    start_time = time.time()
    for _ in (range(num_runs)):
        sol = func()
    end_time = time.time()

    return sol, (end_time - start_time) / num_runs


# comparing rootfinder algorithms

def fcn1_torch(x: torch.Tensor, A: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
    # x: (..., feats_dim, 1)
    # A: (..., feats_dim, feats_dim)
    # b: (..., feats_dim, 1)
    return torch.tanh(torch.einsum("...ij,...jk->...ik", A, x) + b) + x

def fcn1_numpy(x: np.ndarray, A: np.ndarray, b: np.ndarray) -> np.ndarray:
    # x: (..., feats_dim, 1)
    # A: (..., feats_dim, feats_dim)
    # b: (..., feats_dim, 1)
    return np.tanh(np.einsum("...ij,...jk->...ik", A, x) + b) + x

def compare_root():
    torch.manual_seed(0)
    batch_size, feats_dim = 2, 3
    dtype = torch.float64
    method = "broyden2"
    # device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
    device = torch.device("cpu")
    kwargs = {"dtype": dtype, "device": device}

    A = torch.randn(batch_size, feats_dim, feats_dim, **kwargs)
    b = torch.randn(batch_size, feats_dim, 1, **kwargs)
    x0 = torch.randn(batch_size, feats_dim, 1, **kwargs)

    # convert to numpy
    A_np = A.cpu().detach().numpy()
    b_np = b.cpu().detach().numpy()
    x0_np = x0.cpu().detach().numpy()

    num_runs = 100
    # _, time_torch = benchmark_run(lambda: fcn1_torch(x0, A, b), num_runs=num_runs)
    # _, time_numpy = benchmark_run(lambda: fcn1_numpy(x0_np, A_np, b_np), num_runs=num_runs)
    sol_torch, time_torch = benchmark_run(
        lambda: xitorch.optimize.rootfinder(fcn1_torch, x0, (A, b), method=method), num_runs=num_runs)
    print("torch:", time_torch)
    sol_numpy, time_numpy = benchmark_run(
        lambda: root(fcn1_numpy, x0_np, args=(A_np, b_np), method=method), num_runs=num_runs)
    print("numpy:", time_numpy)

if __name__ == "__main__":
    compare_root()
```

After this commit:
```
torch: 0.015993635654449462
numpy: 0.0032497787475585936
```
Before this commit, it was about 0.018.
Ours is about 4-5 times slower and it is because evaluating the function is about 4-5 times slower in pytorch CPU compared to numpy.